### PR TITLE
Don't overwrite existing Content-Type

### DIFF
--- a/api.snap.txt
+++ b/api.snap.txt
@@ -34,8 +34,6 @@ func SeeOther(url string) Response
 
 func (r *Response) Html(html string)
 
-func (r *Response) PredetermineType(mediaType supportedType, contentType string)
-
 func (res *Response) Write(w http.ResponseWriter, r *http.Request, cfg *Config) error
 
 type ServeMux struct {

--- a/response.go
+++ b/response.go
@@ -133,13 +133,15 @@ func (res *Response) Write(w http.ResponseWriter, r *http.Request, cfg *Config) 
 
 	var contentType string
 	if res.predeterminedMediaType != "" {
-		// In this case, assuming mediaType == res.PredeterminedMediaType
+		// In this case, assuming mediaType == res.predeterminedMediaType
 		contentType = res.predeterminedContentType
 	} else {
 		contentType = mediaTypeToContentType[mediaType]
 	}
 	log.Dev("Setting content-type to %#v", contentType)
-	h.Set("Content-Type", contentType)
+	if h.Get("Content-Type") == "" {
+		h.Set("Content-Type", contentType)
+	}
 
 	if res.Status != 0 {
 		w.WriteHeader(res.Status)
@@ -261,15 +263,4 @@ func (r *Response) Html(html string) {
 	r.Body = html
 	r.predeterminedMediaType = mHtml
 	r.predeterminedContentType = mediaTypeToContentType[mHtml]
-}
-
-// Override the media type that rsvp will use.
-//
-// Use this with caution.
-//
-// mediaType MUST be set to one of the supportedTypes to determine which rendering mode to use,
-// but contentType may be any valid value of a Content-Type header
-func (r *Response) PredetermineType(mediaType supportedType, contentType string) {
-	r.predeterminedMediaType = mediaType
-	r.predeterminedContentType = contentType
 }

--- a/response_test.go
+++ b/response_test.go
@@ -245,9 +245,9 @@ func TestRss(t *testing.T) {
 	}
 
 	res := rsvp.Response{Body: body, TemplateName: "rss.gotmpl"}
-	res.PredetermineType("text/html", "application/rss+xml")
 	req := httptest.NewRequest("GET", "/posts.xml", nil)
 	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "application/rss+xml")
 
 	cfg := rsvp.DefaultConfig()
 	// This will make sure rsvp uses the text/html rendering scheme which I use as a hack to avoid rendering non-XML. I should probably just use encoding/xml


### PR DESCRIPTION
No longer exposing the `predeterminedX` stuff. It was a bit contrived anyway. Better to just respect any existing Content-Type header