### PR TITLE
Template responses are not used eagerly

### DIFF
--- a/response.go
+++ b/response.go
@@ -38,20 +38,6 @@ func (res *Response) mediaTypes(cfg *Config) iter.Seq[supportedType] {
 			return
 		}
 
-		if res.TemplateName != "" {
-			if cfg.HtmlTemplate != nil && cfg.HtmlTemplate.Lookup(res.TemplateName) != nil {
-				if !yield(mHtml) {
-					return
-				}
-			}
-
-			if cfg.TextTemplate != nil && cfg.TextTemplate.Lookup(res.TemplateName) != nil {
-				if !yield(mPlaintext) {
-					return
-				}
-			}
-		}
-
 		switch res.Body.(type) {
 		case string:
 			if !yield(mPlaintext) {
@@ -64,6 +50,20 @@ func (res *Response) mediaTypes(cfg *Config) iter.Seq[supportedType] {
 
 		if !yield(mJson) {
 			return
+		}
+
+		if res.TemplateName != "" {
+			if cfg.HtmlTemplate != nil && cfg.HtmlTemplate.Lookup(res.TemplateName) != nil {
+				if !yield(mHtml) {
+					return
+				}
+			}
+
+			if cfg.TextTemplate != nil && cfg.TextTemplate.Lookup(res.TemplateName) != nil {
+				if !yield(mPlaintext) {
+					return
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
If the request is being made without an Accept header, it's likely being made outside of a browser, probably programmatically, in which case a more data-processing-friendly format is probably desired. 
i.e. JSON rather than HTML, which is not as easy to process in a program or on the command-line.