### PR TITLE
Explicitly include body in rsvp.SeeOther call

### DIFF
--- a/api.snap.txt
+++ b/api.snap.txt
@@ -30,7 +30,7 @@ func Ok() Response
 
 func PermanentRedirect(url string) Response
 
-func SeeOther(url string) Response
+func SeeOther(url string, body any) Response
 
 func (r *Response) Html(html string)
 

--- a/response.go
+++ b/response.go
@@ -171,6 +171,10 @@ func (res *Response) Write(w http.ResponseWriter, r *http.Request, cfg *Config) 
 		h.Set("Content-Type", contentType)
 	}
 
+	if res.seeOther != "" {
+		http.Redirect(w, r, res.seeOther, http.StatusSeeOther)
+	}
+
 	if res.Status != 0 {
 		w.WriteHeader(res.Status)
 	}
@@ -242,11 +246,6 @@ func (res *Response) Write(w http.ResponseWriter, r *http.Request, cfg *Config) 
 		return fmt.Errorf("unhandled mediaType: %#v", mediaType)
 	}
 
-	if res.seeOther != "" {
-		http.Redirect(w, r, res.seeOther, http.StatusSeeOther)
-		return nil
-	}
-
 	return nil
 }
 
@@ -256,14 +255,12 @@ func (res *Response) Write(w http.ResponseWriter, r *http.Request, cfg *Config) 
 // this case. For instance, if the request was a JSON PUT from
 // the commandline it's helpful to see the result without having
 // to manually follow the Location header.
-func SeeOther(url string) Response {
+func SeeOther(url string, body any) Response {
 	return Response{
+		Body:     body,
 		seeOther: url,
 
-		// Status must be set here otherwise any writes
-		// to http.ResponseWriter will beat us to the punch
-		Status:            http.StatusSeeOther,
-		blankBodyOverride: true,
+		blankBodyOverride: body == nil,
 	}
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -354,8 +354,7 @@ func TestNilBody(t *testing.T) {
 }
 
 func TestSeeOtherCanRender(t *testing.T) {
-	res := rsvp.SeeOther("/")
-	res.Body = "POST successful"
+	res := rsvp.SeeOther("/", "POST successful")
 	req := httptest.NewRequest("POST", "/", nil)
 	rec := httptest.NewRecorder()
 
@@ -366,12 +365,13 @@ func TestSeeOtherCanRender(t *testing.T) {
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusSeeOther, statusCode)
 	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Location", "/", resp.Header.Get("Location"))
 	s := rec.Body.String()
 	assert.Eq(t, "body contents", res.Body.(string), s)
 }
 
 func TestSeeOtherDoesNotRenderHtml(t *testing.T) {
-	res := rsvp.SeeOther("/")
+	res := rsvp.SeeOther("/", nil)
 	res.Html("<div></div>")
 	req := httptest.NewRequest("POST", "/", nil)
 	rec := httptest.NewRecorder()
@@ -383,6 +383,7 @@ func TestSeeOtherDoesNotRenderHtml(t *testing.T) {
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusSeeOther, statusCode)
 	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Location", "/", resp.Header.Get("Location"))
 	s := rec.Body.String()
 	assert.Eq(t, "body contents", "", s)
 }
@@ -400,6 +401,7 @@ func TestPermanentRedirectDoesNotRender(t *testing.T) {
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusPermanentRedirect, statusCode)
 	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Location", "/", resp.Header.Get("Location"))
 	s := rec.Body.String()
 	assert.Eq(t, "body contents", "", s)
 }
@@ -597,7 +599,7 @@ func TestFirefoxAcceptHeader(t *testing.T) {
 }
 
 func TestSeeOtherBlank(t *testing.T) {
-	res := rsvp.SeeOther("/")
+	res := rsvp.SeeOther("/", nil)
 	req := httptest.NewRequest("POST", "/", nil)
 	rec := httptest.NewRecorder()
 
@@ -608,6 +610,7 @@ func TestSeeOtherBlank(t *testing.T) {
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusSeeOther, statusCode)
 	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Location", "/", resp.Header.Get("Location"))
 	body := rec.Body.String()
 	assert.Eq(t, "body contents", "", body)
 }


### PR DESCRIPTION
I think I want to encourage the idea of rendering a response body for non-HTML 303s

This also contains a fix for the Location header not being set for some cases of rsvp.SeeOther