### PR TITLE
Version 0.21.0: Body data always rendered when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,6 @@ type Body struct {
 ServeHTTP(ResponseWriter, *http.Request) Body
 ```
 
-## Features
-
-- Content Negotiation. rsvp will attempt to provide Data in a supported media type that is requested via the Accept header; or even the URL's file extension in the case of GET requests:
-  - [x] `application/json`
-  - [x] `text/html`
-  - [x] `text/plain`
-  - [x] `text/csv` (by implementing the rsvp.Csv interface)
-  - [x] `application/octet-stream`
-  - [x] `application/xml`
-  - [x] `application/vnd.msgpack` (optional extension behind -tags=rsvp_msgpack)
-  - [ ] Others to be implemented?
-- Extension matching on GET requests:
-  - `/users/123` → Returns default media type (determined by the value of Body)
-  - `/users/123.json` → Forces `application/json`
-  - `/users/123.xml` → Forces `application/xml`
-  - `/users/123.csv` → Forces `text/csv`
-  - NOTE: Currently, this behaviour is hidden behind net/http's strict path matching. The above examples would require something like `mux.Handle("/users/{filename}")` with middleware that strips out the file extension, and matches the remaining file stem with its respective handler. rsvp does not currently provide a utility for this.
-
 It's easy for me to lose track of what I've written to [`http.ResponseWriter`](https://pkg.go.dev/net/http#ResponseWriter). Occasionally receiving the old `http: multiple response.WriteHeader calls`
 
 With this library I just return a value, which I can only ever do once, to execute an HTTP response write. Why write responses with a weird mutable reference from goodness knows where? YEUCH!
@@ -60,6 +42,45 @@ if r.Method != http.MethodPut {
 ```
 
 (Wrapping this with your own convenience method, i.e. `func ErrorMethodNotAllowed(message string) rsvp.Body` is encouraged. You can decide for yourself how errors are represented)
+
+## Features
+
+### Content negotiation
+
+rsvp will attempt to provide Data in a supported media type that is requested via the Accept header; or even the URL's file extension in the case of GET requests:
+
+- [x] `application/json`
+- [x] `text/html`
+- [x] `text/plain`
+- [x] `text/csv` (by implementing the rsvp.Csv interface)
+- [x] `application/octet-stream`
+- [x] `application/xml`
+- [x] `application/vnd.msgpack` (optional extension behind -tags=rsvp_msgpack)
+- [ ] Others to be implemented?
+
+### Extension matching on GET requests
+
+- `/users` → Returns default media type (determined by the value of Body)
+- `/users.json` → Forces `application/json`
+- `/users.xml` → Forces `application/xml`
+- `/users.csv` → Forces `text/csv`
+
+> [!NOTE]
+> This behaviour is slightly hidden behind net/http's strict path matching. It can be exposed with explicit handlers for each extension, e.g.:
+>
+> ```go
+> mux.Handle("/users", listUsers)
+> mux.Handle("/users.json", listUsers)
+> mux.Handle("/users.xml", listUsers)
+> mux.Handle("/users.csv", listUsers)
+> ```
+
+> [!WARN]
+> For dynamic file-matching handlers like this it will work automatically, however you might want to remember to strip the extension from the filename:
+>
+> ```go
+> mux.Handle("/users/{filename}", getUser)
+> ```
 
 ## Comparison
 

--- a/api.snap.txt
+++ b/api.snap.txt
@@ -11,11 +11,6 @@ const (
 	SupportedMediaTypeXml       string = "application/xml"
 )
 
-VARIABLES
-
-var ErrFailedToMatchHtmlTemplate = errors.New("TemplateName was set, but it failed to match within HtmlTemplate")
-var ErrFailedToMatchTextTemplate = errors.New("TemplateName was set, but it failed to match within TextTemplate")
-
 FUNCTIONS
 
 func Write(w http.ResponseWriter, r *http.Request, cfg Config, handler Handler) error

--- a/content.go
+++ b/content.go
@@ -107,11 +107,7 @@ func chooseMediaType(ext string, supported []string, accept iter.Seq[string]) st
 			if slices.Contains(supported, a) {
 				dev.Log("Setting %#v as sole supported type", a)
 				supported = []string{a}
-			} else {
-				supported = []string{}
 			}
-		} else {
-			supported = []string{}
 		}
 	}
 
@@ -171,13 +167,13 @@ func (res *Body) MediaTypes(cfg Config) iter.Seq[string] {
 		}
 
 		if res.TemplateName != "" {
-			if cfg.HtmlTemplate != nil {
+			if cfg.HtmlTemplate != nil && cfg.HtmlTemplate.Lookup(res.TemplateName) != nil {
 				if !yield(SupportedMediaTypeHtml) {
 					return
 				}
 			}
 
-			if cfg.TextTemplate != nil {
+			if cfg.TextTemplate != nil && cfg.TextTemplate.Lookup(res.TemplateName) != nil {
 				if !yield(SupportedMediaTypePlaintext) {
 					return
 				}

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -31,13 +31,17 @@ func FatalErr(t *testing.T, context string, err error) {
 }
 
 func FatalErrIs(t *testing.T, context string, err, target error) {
-	if !errors.Is(err, target) {
+	if err == nil {
+		t.Fatalf("%s: expected an error but got nil", context)
+	} else if !errors.Is(err, target) {
 		t.Fatalf("%s: encountered unexpected error: %s", context, err)
 	}
 }
 
 func FatalErrAs(t *testing.T, context string, err error, target any) {
-	if !errors.As(err, target) {
+	if err == nil {
+		t.Fatalf("%s: expected an error but got nil", context)
+	} else if !errors.As(err, target) {
 		t.Fatalf("%s: encountered unexpected error: %s", context, err)
 	}
 }

--- a/mediatypes_test.go
+++ b/mediatypes_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/Teajey/rsvp/internal/assert"
 )
 
+var htmlTemplate *html.Template
+var textTemplate *text.Template
+
+func TestMain(m *testing.M) {
+	htmlTemplate = html.Must(html.New("").Parse(`{{ define "tm" }}TEMPLATE{{end}}`))
+	textTemplate = text.Must(text.New("").Parse(`{{ define "tm" }}TEMPLATE{{end}}`))
+	m.Run()
+}
+
 func TestNilResponse(t *testing.T) {
 	cfg := rsvp.Config{}
 	resp := rsvp.Data(nil)
@@ -151,7 +160,7 @@ func TestCsvResponse(t *testing.T) {
 
 func TestStructResponseWithHtmlTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
+		HtmlTemplate: htmlTemplate,
 	}
 	resp := rsvp.Body{Data: struct{}{}, TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -168,7 +177,7 @@ func TestStructResponseWithHtmlTemplate(t *testing.T) {
 
 func TestStructWithoutTemplateNameResponseWithHtmlTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
+		HtmlTemplate: htmlTemplate,
 	}
 	resp := rsvp.Body{Data: struct{}{}, TemplateName: ""}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -184,7 +193,7 @@ func TestStructWithoutTemplateNameResponseWithHtmlTemplate(t *testing.T) {
 
 func TestCsvResponseWithHtmlTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
+		HtmlTemplate: htmlTemplate,
 	}
 	resp := rsvp.Body{Data: myCsv{}, TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -202,7 +211,7 @@ func TestCsvResponseWithHtmlTemplate(t *testing.T) {
 
 func TestCsvResponseWithTextTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		TextTemplate: text.New(""),
+		TextTemplate: textTemplate,
 	}
 	resp := rsvp.Body{Data: myCsv{}, TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -220,7 +229,7 @@ func TestCsvResponseWithTextTemplate(t *testing.T) {
 
 func TestStructResponseWithTextTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		TextTemplate: text.New(""),
+		TextTemplate: textTemplate,
 	}
 	resp := rsvp.Body{Data: struct{}{}, TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -237,7 +246,7 @@ func TestStructResponseWithTextTemplate(t *testing.T) {
 
 func TestStructWithoutTemplateNameResponseWithTextTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		TextTemplate: text.New(""),
+		TextTemplate: textTemplate,
 	}
 	resp := rsvp.Body{Data: struct{}{}, TemplateName: ""}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -253,8 +262,8 @@ func TestStructWithoutTemplateNameResponseWithTextTemplate(t *testing.T) {
 
 func TestStructResponseWithTextAndHtmlTemplates(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
-		TextTemplate: text.New(""),
+		HtmlTemplate: htmlTemplate,
+		TextTemplate: textTemplate,
 	}
 	resp := rsvp.Body{Data: struct{}{}, TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -272,8 +281,8 @@ func TestStructResponseWithTextAndHtmlTemplates(t *testing.T) {
 
 func TestStringResponseWithTextAndHtmlTemplates(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
-		TextTemplate: text.New(""),
+		HtmlTemplate: htmlTemplate,
+		TextTemplate: textTemplate,
 	}
 	resp := rsvp.Body{Data: "Hello", TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -292,8 +301,8 @@ func TestStringResponseWithTextAndHtmlTemplates(t *testing.T) {
 
 func TestCsvResponseWithTextAndHtmlTemplates(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
-		TextTemplate: text.New(""),
+		HtmlTemplate: htmlTemplate,
+		TextTemplate: textTemplate,
 	}
 	resp := rsvp.Body{Data: myCsv{}, TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -312,7 +321,7 @@ func TestCsvResponseWithTextAndHtmlTemplates(t *testing.T) {
 
 func TestBytesResponseWithHtmlTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
+		HtmlTemplate: htmlTemplate,
 	}
 	resp := rsvp.Body{Data: []byte("Hello"), TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))
@@ -330,7 +339,7 @@ func TestBytesResponseWithHtmlTemplate(t *testing.T) {
 
 func TestStringResponseWithHtmlTemplate(t *testing.T) {
 	cfg := rsvp.Config{
-		HtmlTemplate: html.New(""),
+		HtmlTemplate: htmlTemplate,
 	}
 	resp := rsvp.Body{Data: "Hello", TemplateName: "tm"}
 	actual := slices.Collect(resp.MediaTypes(cfg))

--- a/response_test.go
+++ b/response_test.go
@@ -109,7 +109,7 @@ World!`
 	assert.Eq(t, "body contents", "\"Hello,\\nWorld!\""+"\n", s)
 }
 
-func TestUnsupportedExtHasBlank404(t *testing.T) {
+func TestUnsupportedExt(t *testing.T) {
 	body := `Hello,
 World!`
 	res := rsvp.Body{Data: body}
@@ -126,10 +126,10 @@ World!`
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", 404, statusCode)
 
-	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Content type", "application/json", resp.Header.Get("Content-Type"))
 
 	s := rec.Body.String()
-	assert.Eq(t, "body contents", "", s)
+	assert.Eq(t, "body contents", "\"Hello,\\nWorld!\"\n", s)
 }
 
 func TestListBody(t *testing.T) {
@@ -267,7 +267,7 @@ func TestTextTemplateWithoutName(t *testing.T) {
 	assert.Eq(t, "body contents", "Hello, World!", s)
 }
 
-func TestHtmlTemplateMiss(t *testing.T) {
+func TestHtmlTemplateMissAccept(t *testing.T) {
 	body := "Hello <input> World!"
 	res := rsvp.Body{Data: body, TemplateName: "tn"}
 	req := httptest.NewRequest("GET", "/", nil)
@@ -278,11 +278,66 @@ func TestHtmlTemplateMiss(t *testing.T) {
 	cfg.HtmlTemplate = html.Must(html.New("tm").Parse(`<div>{{if .}}{{.}}{{else}}Nothin!{{end}}</div>`))
 
 	err := makeHandler(res, cfg)(rec, req)
-	assert.FatalErrIs(t, "handler", err, rsvp.ErrFailedToMatchHtmlTemplate)
+	assert.FatalErr(t, "handler", err)
+
+	resp := rec.Result()
+	statusCode := resp.StatusCode
+	assert.Eq(t, "Status code", http.StatusNotAcceptable, statusCode)
+
+	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	s := rec.Body.String()
+	assert.Eq(t, "body contents", "Hello <input> World!", s)
 }
 
-func TestTextTemplateMiss(t *testing.T) {
-	body := "Hello, World!"
+func TestHtmlTemplateMissExt(t *testing.T) {
+	body := "Hello <input> World!"
+	res := rsvp.Body{Data: body, TemplateName: "tn"}
+	req := httptest.NewRequest("GET", "/message.html", nil)
+	rec := httptest.NewRecorder()
+
+	cfg := rsvp.Config{}
+	cfg.HtmlTemplate = html.Must(html.New("tm").Parse(`<div>{{if .}}{{.}}{{else}}Nothin!{{end}}</div>`))
+
+	err := makeHandler(res, cfg)(rec, req)
+	assert.FatalErr(t, "handler", err)
+
+	resp := rec.Result()
+	statusCode := resp.StatusCode
+	assert.Eq(t, "Status code", 404, statusCode)
+
+	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	s := rec.Body.String()
+	assert.Eq(t, "body contents", body, s)
+}
+
+func TestTextTemplateMissAccept(t *testing.T) {
+	body := map[string]string{"msg": "Hello, World!"}
+	res := rsvp.Body{Data: body, TemplateName: "tn"}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "text/plain")
+	rec := httptest.NewRecorder()
+
+	cfg := rsvp.Config{}
+	cfg.TextTemplate = text.New("")
+	cfg.TextTemplate = text.Must(cfg.TextTemplate.Parse(`{{define "tm"}}{{with .msg}}Message: {{.}}{{else}}Nothin!{{end}}{{end}}`))
+
+	err := makeHandler(res, cfg)(rec, req)
+	assert.FatalErr(t, "handler", err)
+
+	resp := rec.Result()
+	statusCode := resp.StatusCode
+	assert.Eq(t, "Status code", http.StatusNotAcceptable, statusCode)
+
+	assert.Eq(t, "Content type", "application/json", resp.Header.Get("Content-Type"))
+
+	s := rec.Body.String()
+	assert.Eq(t, "body contents", `{"msg":"Hello, World!"}`+"\n", s)
+}
+
+func TestTextTemplateMissExt(t *testing.T) {
+	body := map[string]string{"msg": "Hello, World!"}
 	res := rsvp.Body{Data: body, TemplateName: "tn"}
 	req := httptest.NewRequest("GET", "/message.txt", nil)
 	rec := httptest.NewRecorder()
@@ -292,7 +347,16 @@ func TestTextTemplateMiss(t *testing.T) {
 	cfg.TextTemplate = text.Must(cfg.TextTemplate.Parse(`{{define "tm"}}{{if .}}Message: {{.}}{{else}}Nothin!{{end}}{{end}}`))
 
 	err := makeHandler(res, cfg)(rec, req)
-	assert.FatalErrIs(t, "handler", err, rsvp.ErrFailedToMatchTextTemplate)
+	assert.FatalErr(t, "handler", err)
+
+	resp := rec.Result()
+	statusCode := resp.StatusCode
+	assert.Eq(t, "Status code", 404, statusCode)
+
+	assert.Eq(t, "Content type", "application/json", resp.Header.Get("Content-Type"))
+
+	s := rec.Body.String()
+	assert.Eq(t, "body contents", `{"msg":"Hello, World!"}`+"\n", s)
 }
 
 func TestAttemptToRenderNonTextAsText(t *testing.T) {
@@ -309,10 +373,10 @@ func TestAttemptToRenderNonTextAsText(t *testing.T) {
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", 404, statusCode)
 
-	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Content type", "application/json", resp.Header.Get("Content-Type"))
 
 	s := rec.Body.String()
-	assert.Eq(t, "body contents", "", s)
+	assert.Eq(t, "body contents", `{"I'm":"a map"}`+"\n", s)
 }
 
 func TestRss(t *testing.T) {
@@ -511,7 +575,7 @@ func TestSeeOtherCanRender(t *testing.T) {
 	assert.Eq(t, "body contents", res.Data.(string), s)
 }
 
-func TestSeeOtherDoesNotRenderWithoutAccept(t *testing.T) {
+func TestSeeOtherWithData(t *testing.T) {
 	res := rsvp.Body{Data: "See other"}.StatusSeeOther("/")
 	req := httptest.NewRequest("POST", "/", nil)
 	rec := httptest.NewRecorder()
@@ -522,10 +586,10 @@ func TestSeeOtherDoesNotRenderWithoutAccept(t *testing.T) {
 	resp := rec.Result()
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusSeeOther, statusCode)
-	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 	assert.Eq(t, "Location", "/", resp.Header.Get("Location"))
 	s := rec.Body.String()
-	assert.Eq(t, "body contents", "", s)
+	assert.Eq(t, "body contents", "See other", s)
 }
 
 func TestFoundCanRender(t *testing.T) {
@@ -546,7 +610,7 @@ func TestFoundCanRender(t *testing.T) {
 	assert.Eq(t, "body contents", res.Data.(string), s)
 }
 
-func TestFoundDoesNotRenderHtmlWithoutAccept(t *testing.T) {
+func TestFoundWithData(t *testing.T) {
 	res := rsvp.Body{Data: "Found"}.StatusFound("/")
 	req := httptest.NewRequest("POST", "/", nil)
 	rec := httptest.NewRecorder()
@@ -557,15 +621,14 @@ func TestFoundDoesNotRenderHtmlWithoutAccept(t *testing.T) {
 	resp := rec.Result()
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusFound, statusCode)
-	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 	assert.Eq(t, "Location", "/", resp.Header.Get("Location"))
 	s := rec.Body.String()
-	assert.Eq(t, "body contents", "", s)
+	assert.Eq(t, "body contents", "Found", s)
 }
 
-func TestPermanentRedirectDoesNotRenderWithoutAccept(t *testing.T) {
+func TestPermanentRedirectWithData(t *testing.T) {
 	res := rsvp.Body{Data: "Permanent redirect"}.StatusPermanentRedirect("/")
-	res.Data = "POST successful"
 	req := httptest.NewRequest("POST", "/", nil)
 	rec := httptest.NewRecorder()
 
@@ -575,10 +638,10 @@ func TestPermanentRedirectDoesNotRenderWithoutAccept(t *testing.T) {
 	resp := rec.Result()
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusPermanentRedirect, statusCode)
-	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 	assert.Eq(t, "Location", "/", resp.Header.Get("Location"))
 	s := rec.Body.String()
-	assert.Eq(t, "body contents", "", s)
+	assert.Eq(t, "body contents", "Permanent redirect", s)
 }
 
 func TestMovedPermanentlyDoesRender(t *testing.T) {
@@ -649,12 +712,12 @@ func TestExplicitTextRequestWithoutTextTemplate(t *testing.T) {
 
 	resp := rec.Result()
 	statusCode := resp.StatusCode
-	assert.Eq(t, "Status code", http.StatusNotFound, statusCode)
+	assert.Eq(t, "Status code", http.StatusOK, statusCode)
 
-	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 
 	s := rec.Body.String()
-	assert.Eq(t, "body contents", "", s)
+	assert.Eq(t, "body contents", "Hello <input> World!", s)
 }
 
 func TestExplicitHtmlRequestWithoutHtmlTemplate(t *testing.T) {
@@ -673,10 +736,10 @@ func TestExplicitHtmlRequestWithoutHtmlTemplate(t *testing.T) {
 	statusCode := resp.StatusCode
 	assert.Eq(t, "Status code", http.StatusNotFound, statusCode)
 
-	assert.Eq(t, "Content type", "", resp.Header.Get("Content-Type"))
+	assert.Eq(t, "Content type", "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 
 	s := rec.Body.String()
-	assert.Eq(t, "body contents", "", s)
+	assert.Eq(t, "body contents", `Message: Hello <input> World!`, s)
 }
 
 func TestNestedFile(t *testing.T) {

--- a/writing.go
+++ b/writing.go
@@ -89,7 +89,7 @@ func (w *responseWriter) write(res *Body, r *http.Request, cfg Config) (err erro
 
 		wh.Set("Location", res.redirectLocation)
 
-		if res.isBlank() || accept == "" {
+		if res.isBlank() {
 			dev.Log("Redirect returning empty")
 			w.writer.WriteHeader(status)
 			return
@@ -105,24 +105,18 @@ func (w *responseWriter) write(res *Body, r *http.Request, cfg Config) (err erro
 		return
 	}
 
-	if mediaType == "" {
-		if ext != "" {
-			a, ok := extToProposalMap[ext]
-			if !ok || !slices.Contains(supported, a) {
-				w.writer.WriteHeader(http.StatusNotFound)
-				return
-			}
+	if ext != "" {
+		a, ok := extToProposalMap[ext]
+		if !ok || !slices.Contains(supported, a) {
+			status = http.StatusNotFound
 		}
+	}
 
+	if mediaType == "" {
 		dev.Log("NotAcceptable. Ignoring Accept header and setting status code to 406...")
 		status = http.StatusNotAcceptable
 		mediaType = chooseMediaType(ext, supported, content.ParseAccept(""))
 		dev.Log("new mediaType %#v", mediaType)
-	}
-
-	if mediaType == "text/plain" && cfg.TextTemplate == nil && res.TemplateName != "" {
-		w.writer.WriteHeader(http.StatusNotFound)
-		return
 	}
 
 	if !res.isBlank() && contentType == "" {
@@ -139,9 +133,6 @@ func (w *responseWriter) write(res *Body, r *http.Request, cfg Config) (err erro
 	err = render(res, mediaType, w.writer, cfg)
 	return
 }
-
-var ErrFailedToMatchTextTemplate = errors.New("TemplateName was set, but it failed to match within TextTemplate")
-var ErrFailedToMatchHtmlTemplate = errors.New("TemplateName was set, but it failed to match within HtmlTemplate")
 
 const templateErrorMessage = "rsvp stopped writing here because of a template error"
 
@@ -162,14 +153,14 @@ func render(res *Body, mediaType string, w io.Writer, cfg Config) error {
 				break
 			}
 
-			return ErrFailedToMatchHtmlTemplate
+			return errors.New("failed to match TemplateName within HtmlTemplate")
 		}
-		return fmt.Errorf("not using a template because either HtmlTemplate or TemplateName is not set")
+		return fmt.Errorf("failed to render HTML because either HtmlTemplate or TemplateName is not set")
 	case SupportedMediaTypePlaintext:
 		dev.Log("Rendering plain text...")
 
 		if res.TemplateName != "" && cfg.TextTemplate != nil {
-			dev.Log("Template name is set, so expecting a template...")
+			dev.Log("Template name is set, so looking for a template...")
 
 			if tm := cfg.TextTemplate.Lookup(res.TemplateName); tm != nil {
 				dev.Log("Executing TextTemplate...")
@@ -180,10 +171,8 @@ func render(res *Body, mediaType string, w io.Writer, cfg Config) error {
 				}
 				break
 			}
-
-			return ErrFailedToMatchTextTemplate
 		}
-		dev.Log("Not using a template because either TextTemplate or TemplateName is not set...")
+		dev.Log("Not using a template because either TemplateName is not set, or it did not find a match...")
 
 		if data, ok := res.Data.(string); ok {
 			dev.Log("Can write data directly because it is a string...")


### PR DESCRIPTION
It's a waste to run the whole handler only for it to not be returned in any form just because rsvp decided not to.